### PR TITLE
fix(ci): Replace `npm install -g @go-task/cli` with `go-task/setup-task` action to eliminate npm supply-chain risk; Use reusable CI actions from `yscope-dev-utils`; Bump `actions/checkout` to v6.0.2.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
             runner: "ubuntu-24.04-arm"
             manylinux: "quay.io/pypa/manylinux_2_28_aarch64"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: "write"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
 
       - name: "Download merged artifacts"
         uses: "actions/download-artifact@v4"
@@ -128,7 +128,7 @@ jobs:
             image: "fluent-bit-clp-s3-v2"
             platforms: "linux/amd64,linux/arm64"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,8 +22,9 @@ jobs:
           go-version: "${{ matrix.go }}"
 
       - name: "Install task"
-        shell: "bash"
-        run: "npm install -g @go-task/cli"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - name: "Install uv"
         shell: "bash"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 
@@ -21,14 +21,11 @@ jobs:
         with:
           go-version: "${{ matrix.go }}"
 
-      - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
+      - name: "Install go-task"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
       - name: "Install uv"
-        shell: "bash"
-        run: "curl --fail --location --silent --show-error https://astral.sh/uv/install.sh | sh"
+        uses: "./tools/yscope-dev-utils/exports/github/actions/install-uv"
 
       - name: "Run linting checks"
         run: "task lint:check"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

All CI workflows install the Task runner via `npm install -g @go-task/cli`. `@go-task/cli` declares
a transitive dependency on `axios: ^1.8.2`, and because global npm installs have no lock file, npm
resolves to whatever the latest semver-compatible version is at install time. During the
[axios supply-chain compromise on 2026-03-31][axios-advisory], this caused CI runners to pull in the
malicious `axios@1.14.1` package, which executed a post-install script that connected to an
attacker-controlled C2 server.

This PR:

1. **Replaces `npm install -g @go-task/cli`** with reusable CI actions from the `yscope-dev-utils`
   submodule (updated to [`38bf51e`][yscope-dev-utils-commit]), which wraps the official
   [`go-task/setup-task`][setup-task] action pinned by commit SHA. The action downloads the Task
   binary directly from GitHub Releases without involving npm, eliminating the transitive dependency
   on axios and the broader npm supply-chain attack surface.
2. **Replaces the standalone `curl`-based `uv` install** in the lint workflow with the reusable
   `install-uv` action from `yscope-dev-utils`, which uses [`astral-sh/setup-uv`][setup-uv] pinned
   by commit SHA.
3. **Bumps `actions/checkout`** from `v4` (unpinned tag) to
   [`v6.0.2`][checkout-v6] (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`), pinned by commit SHA
   across all workflows.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. Verified that no `npm install -g` commands remain in any workflow file.
2. Confirmed the pinned commit SHA `3be4020d41929789a01026e0e427a4321ce0ad44` corresponds to
   `go-task/setup-task` [v2.0.0][setup-task-v2].
3. Verified the `yscope-dev-utils` submodule is updated to `38bf51e` and its reusable actions are
   correctly referenced in the lint workflow.
4. Confirmed all `actions/checkout` references are pinned to
   `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2).

[axios-advisory]: https://github.com/advisories/GHSA-fw8c-xr5c-95f9
[checkout-v6]: https://github.com/actions/checkout/releases/tag/v6.0.2
[setup-task]: https://github.com/go-task/setup-task
[setup-task-v2]: https://github.com/go-task/setup-task/releases/tag/v2.0.0
[setup-uv]: https://github.com/astral-sh/setup-uv
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
[yscope-dev-utils-commit]: https://github.com/y-scope/yscope-dev-utils/commit/38bf51effc500a528c37052345c141a65ea88447